### PR TITLE
remove error document from s3 configuration

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -20,7 +20,6 @@ module "www_bucket" {
 
   website = {
     index_document = "index.html"
-    error_document = "404.html"
   }
   cors_rule = [
     {


### PR DESCRIPTION
Custom 404 error document is still configured on the cloudfront distribution. Removing the custom document from the s3 bucket config fixes some bad behavior when someone attempts to visit the bucket http endpoint directly.